### PR TITLE
fix(docker): add dockerhub multi images support

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -25,8 +25,21 @@ jobs:
         uses: docker/metadata-action@v5.5.1
         with:
           images: ${{ github.repository }}
+      
+        # The development image has the dev dependencies 
+        # that enables nodemon and its real-time vigilance
+      - name: Build and push the development Docker image
+        uses: docker/build-push-action@v6.7.0
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ github.repository }}:dev
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            TARGET=development
 
-      - name: Build and push Docker image
+      - name: Build and push the production-ready Docker image
         uses: docker/build-push-action@v6.7.0
         with:
           context: .
@@ -34,6 +47,8 @@ jobs:
           push: true
           tags: ${{ github.repository }}:latest
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            TARGET=production
 
       - name: Log out from Docker Hub
         run: docker logout


### PR DESCRIPTION
This pull request includes changes to the Docker publishing workflow to separate the build and push steps for development and production Docker images.

### Changes to Docker Publishing Workflow:

* `.github/workflows/docker-publish.yml`: 
  - Added a new step to build and push the development Docker image with dev dependencies, which includes `nodemon` for real-time vigilance. (`[.github/workflows/docker-publish.ymlL29-R51](diffhunk://#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98L29-R51)`)
  - Renamed the existing step to clearly indicate it builds and pushes the production-ready Docker image. (`[.github/workflows/docker-publish.ymlL29-R51](diffhunk://#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98L29-R51)`)