### PR TITLE
fix(refs): update refs for compose and docker publish

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -25,6 +25,18 @@ jobs:
         uses: docker/metadata-action@v5.5.1
         with:
           images: ${{ github.repository }}
+      
+        # The development image has the dev dependencies 
+        # that enables nodemon and its real-time vigilance
+      - name: Build and push the development Docker image
+        uses: docker/build-push-action@v6.7.0
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ github.repository }}:dev
+          labels: ${{ steps.meta.outputs.labels }}
+          target: development
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6.7.0
@@ -34,6 +46,7 @@ jobs:
           push: true
           tags: ${{ github.repository }}:latest
           labels: ${{ steps.meta.outputs.labels }}
+          target: production
 
       - name: Log out from Docker Hub
         run: docker logout

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   backend:
-    image: fedoteh/pet-manager-api:latest
+    image: fedoteh/pet-manager-api:dev
     # if the image can't be reached, builds the image
     # from the Dockerfile in the current directory.
     # Use `docker compose up --build` to force a local build 


### PR DESCRIPTION
This pull request introduces changes to the Docker workflow and configuration files to support a development environment. The most important changes include adding a new job to build and push a development Docker image, specifying the target stage for the production image, and updating the `docker-compose.yml` to use the development image.

Changes to Docker workflow:

* [`.github/workflows/docker-publish.yml`](diffhunk://#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98R29-R40): Added a new job to build and push the development Docker image with dev dependencies, enabling nodemon for real-time vigilance.
* [`.github/workflows/docker-publish.yml`](diffhunk://#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98R49): Updated the existing job to specify the `production` target stage for the production Docker image.

Changes to Docker configuration:

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L3-R3): Updated the backend service to use the development Docker image `fedoteh/pet-manager-api:dev` instead of the latest production image.