### PR TITLE
Tests imports refactored and nodemon flag for Windows compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "test": "jest",
-    "dev": "nodemon src/app.ts",
+    "dev": "nodemon -L src/app.ts",
     "build": "tsc -p .",
     "start": "node -r module-alias/register dist/app.js"
   },

--- a/src/tests/api/petsRouter.test.ts
+++ b/src/tests/api/petsRouter.test.ts
@@ -2,8 +2,8 @@
 
 import request from 'supertest';
 import express from 'express';
-import petsRouter from '@routes/v1/pets/petsRouter';
-import { Species } from '@util/types/types';
+import petsRouter from '../../routes/v1/pets/petsRouter';
+import { Species } from '../../util/types/types';
 
 const app = express();
 app.use('/pets', petsRouter);

--- a/src/tests/api/routes/catsRouter.test.ts
+++ b/src/tests/api/routes/catsRouter.test.ts
@@ -1,7 +1,7 @@
 import request from 'supertest';
 import express from 'express';
-import catsRouter from '@routes/v1/pets/cats/catsRouter';
-import cats from '@db_mock/cats';
+import catsRouter from '../../../routes/v1/pets/cats/catsRouter';
+import cats from '../../../db_mock/cats';
 
 const app = express();
 app.use(express.json());

--- a/src/tests/api/routes/dogsRouter.test.ts
+++ b/src/tests/api/routes/dogsRouter.test.ts
@@ -1,7 +1,7 @@
 import request from 'supertest';
 import express from 'express';
-import dogsRouter from '@routes/v1/pets/dogs/dogsRouter';
-import dogs from '@db_mock/dogs';
+import dogsRouter from '../../../routes/v1/pets/dogs/dogsRouter';
+import dogs from '../../../db_mock/dogs';
 
 const app = express();
 app.use(express.json());


### PR DESCRIPTION
This pull request includes changes to improve the development workflow and correct import paths in test files. The most important changes are the addition of the `-L` flag to the `nodemon` script and the adjustment of relative import paths in the test files for consistency.

Improvements to development workflow:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L10-R10): Added the `-L` flag to the `nodemon` script in the `dev` command to ensure proper file watching on some file systems.

Adjustments to import paths in test files:

* [`src/tests/api/petsRouter.test.ts`](diffhunk://#diff-06225327c241845e6db4432e816446923ed7500e574bdf718ea51c3c1b13e633L5-R6): Updated import paths for `petsRouter` and `Species` to use relative paths instead of module aliases.
* [`src/tests/api/routes/catsRouter.test.ts`](diffhunk://#diff-6cbed8b65021340215f8a300780455b88dc7e0c5d19f332956afa4121029bbb0L3-R4): Updated import paths for `catsRouter` and `cats` to use relative paths instead of module aliases.
* [`src/tests/api/routes/dogsRouter.test.ts`](diffhunk://#diff-479ef482e97c49c342a8771121dbbe0ea7a6ea924759a056dd0c4f8624aef1dbL3-R4): Updated import paths for `dogsRouter` and `dogs` to use relative paths instead of module aliases.