### PR TITLE
fix: dockerignore has been updated

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,11 @@
-# Ignore the data directory
 data
-
-# Ignore db directory used for postgres
 db
-
-
+node_modules
+.env
+.git
+.gitignore
+Makefile
+__tests__
+dist
+docker-compose.yml
+docker-compose.prod.yml

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -115,5 +115,5 @@
     "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "src/tests"]
+  "exclude": ["node_modules", "dist", "__tests__"]
 }


### PR DESCRIPTION
This pull request updates the `.dockerignore` file to better align with the project's current structure and development practices. The most important changes include adding several directories and files to the ignore list to streamline the Docker build process.

Updates to `.dockerignore`:

* Added `node_modules` directory to ignore list.
* Added `.env` file to ignore list.
* Added `.git` directory and `.gitignore` file to ignore list.
* Added `Makefile` to ignore list.
* Added `__tests__` directory to ignore list.
* Added `dist` directory to ignore list.
* Added `docker-compose.yml` and `docker-compose.prod.yml` files to ignore list.