### PR TITLE
Fix sequelize on local runs with the prod image

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -13,7 +13,6 @@ services:
     env_file:
       - .env
     environment:
-      - DB_HOST=db
       - DB_PORT=5432
       - DB_NAME=${DB_NAME} 
       - DB_USER=${DB_USER}

--- a/src/util/db/sequelize.ts
+++ b/src/util/db/sequelize.ts
@@ -1,17 +1,31 @@
 import { Sequelize } from 'sequelize';
 
+const baseOptions = {
+  host: process.env.DB_HOST as string,
+  port: parseInt(process.env.DB_PORT || '5432', 10),
+  dialect: 'postgres',
+  logging: false,
+};
+
+const localOptions = process.env.NODE_ENV === 'local' ? {
+  dialectOptions: {
+    ssl: {
+      require: true,
+      rejectUnauthorized: false, // You might want to set this to true in production
+    },
+  },
+} : {};
+
+const sequelizeOptions = {
+  ...baseOptions,
+  ...localOptions,
+};
 
 const sequelize = new Sequelize(
   process.env.DB_NAME as string,
   process.env.DB_USER as string,
   process.env.DB_PASSWORD as string,
-  {
-    host: process.env.DB_HOST as string,
-    port: parseInt(process.env.DB_PORT || '5432', 10),
-    dialect: 'postgres',
-    logging: false,
-  }
+  sequelizeOptions as any,
 );
-
 
 export default sequelize;


### PR DESCRIPTION
This pull request includes changes to the database configuration in the `docker-compose.prod.yml` file and the Sequelize setup in `src/util/db/sequelize.ts` to improve environment-specific configurations.

Database configuration improvements:

* [`docker-compose.prod.yml`](diffhunk://#diff-4563fbe997bbf18c3b38ad79c596c57c3ad88361f1dccb8c4f39b429382c06d3L16): Removed the `DB_HOST` environment variable.

Sequelize setup enhancements:

* [`src/util/db/sequelize.ts`](diffhunk://#diff-c7f54b4bb1e35d5fdb282615d372c79133b49edec56c59e5e62a28a85f5f525dR3-L16): Introduced `baseOptions` and `localOptions` to handle common and environment-specific configurations, respectively. Combined these into `sequelizeOptions` to streamline the Sequelize initialization process.