### PR TITLE
feat(render): add deploy hook for render cd

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -50,3 +50,10 @@ jobs:
 
       - name: Log out from Docker Hub
         run: docker logout
+
+      - name: Deploy on Render
+        if: github.ref == 'refs/heads/main'
+        env:
+          deploy_url: ${{ secrets.RENDER_DEPLOY_HOOK_URL }}
+        run: |
+          curl "$deploy_url"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,9 +20,6 @@ services:
     environment:
       - DB_HOST=db
       - DB_PORT=5432
-    #   - DB_NAME=${DB_NAME} 
-    #   - DB_USER=${DB_USER}
-    #   - DB_PASSWORD=${DB_PASSWORD}
     depends_on:
       db:
         condition: service_healthy
@@ -39,10 +36,6 @@ services:
       - ./db/init:/docker-entrypoint-initdb.d
     env_file:
       - .env.local
-    # environment:
-    #   - POSTGRES_DB=${DB_NAME}
-    #   - POSTGRES_USER=${DB_USER}
-    #   - POSTGRES_PASSWORD=${DB_PASSWORD}
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${DB_USER} -d ${DB_NAME}"]
       interval: 10s


### PR DESCRIPTION
The current changes involve adding a deployment step for Render in the GitHub Actions workflow and cleaning up commented-out environment variables in the `docker-compose.yml` file.

Deployment process improvements:

* [`.github/workflows/docker-publish.yml`](diffhunk://#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98R53-R59): Added a step to deploy on Render after logging out from Docker Hub, which runs only on the `main` branch.

Configuration file cleanup:

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L23-L25): Removed commented-out environment variables under the `services:` section to clean up the file. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L23-L25) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L42-L45)